### PR TITLE
Fix invalid article column

### DIFF
--- a/src/Resources/contao/classes/FModuleInsertTags.php
+++ b/src/Resources/contao/classes/FModuleInsertTags.php
@@ -593,7 +593,7 @@ class FModuleInsertTags extends Frontend
                 }
 
                 $objRow->classes = $arrCss;
-                $detailStr .= $this->getContentElement($objRow, $this->strColumn);
+                $detailStr .= $this->getContentElement($objRow);
                 ++$intCount;
             }
         }
@@ -621,7 +621,7 @@ class FModuleInsertTags extends Frontend
                 }
 
                 $objRow->classes = $arrCss;
-                $teaserStr .= $this->getContentElement($objRow, $this->strColumn);
+                $teaserStr .= $this->getContentElement($objRow);
                 ++$intCount;
             }
         }


### PR DESCRIPTION
This fixed new fragments content elements in Contao 4. `$this->strColumn` does not exist in this class, but the parameter is mandatory to be a `string` in Contao 4 fragments.